### PR TITLE
Added initial IMDB data schemas and processing

### DIFF
--- a/imdb_spark_utils.py
+++ b/imdb_spark_utils.py
@@ -1,0 +1,60 @@
+from pyspark.sql import SparkSession, DataFrame
+import pyspark.sql.types as t
+import pyspark.sql.functions as F
+
+
+def initialize_spark(app_name: str = "IMDB Data Processor") -> SparkSession:
+    return SparkSession.builder.appName(app_name).getOrCreate()
+
+
+def load_dataframe(spark: SparkSession, schema: t.StructType, file_path: str) -> DataFrame:
+    return spark.read.option("delimiter", "\t") \
+        .option("header", "true") \
+        .option("nullValue", "\\N") \
+        .option("dateFormat", "MM/dd/yyyy") \
+        .schema(schema) \
+        .csv(file_path)
+
+
+def clean_null_values(df: DataFrame) -> DataFrame:
+    return df.replace("\\N", None)
+
+
+def transform_title_basics(df: DataFrame) -> DataFrame:
+    df = clean_null_values(df)
+    df = df.withColumn("genres", F.split(F.col("genres"), ",").cast("array<string>"))
+    df = df.withColumn("isAdult", F.col("isAdult").cast(t.BooleanType()))
+    return df
+
+
+def transform_title_akas(df: DataFrame) -> DataFrame:
+    df = clean_null_values(df)
+    df = df.withColumn("isOriginalTitle", F.col("isOriginalTitle").cast(t.BooleanType()))
+    df = df.withColumn("types", F.split(F.col("types"), ",").cast("array<string>"))
+    df = df.withColumn("attributes", F.split(F.col("attributes"), ",").cast("array<string>"))
+    return df
+
+
+def transform_title_crew(df: DataFrame) -> DataFrame:
+    df = clean_null_values(df)
+    df = df.withColumn("directors", F.split(F.col("directors"), ",").cast("array<string>"))
+    df = df.withColumn("writers", F.split(F.col("writers"), ",").cast("array<string>"))
+    return df
+
+
+def transform_title_episode(df: DataFrame) -> DataFrame:
+    return clean_null_values(df)
+
+
+def display_dataframe_info(df: DataFrame, name: str) -> None:
+    print(f"\n=== {name} ===")
+    print("First 5 rows:")
+    df.show(5, truncate=False)
+
+    print("Schema:")
+    df.printSchema()
+
+    print("Columns:", df.columns)
+    print("Number of columns:", len(df.columns))
+    print("Number of rows:", df.count())
+

--- a/main.py
+++ b/main.py
@@ -1,8 +1,26 @@
 from pyspark.sql import SparkSession
 import os
-
+from pyspark.sql import DataFrame
+from typing import Dict
+from schemas import (
+    schema_title_basics,
+    schema_title_episode,
+    schema_title_crew,
+    schema_title_akas
+)
+from imdb_spark_utils import (
+    initialize_spark,
+    load_dataframe,
+    transform_title_basics,
+    transform_title_akas,
+    transform_title_crew,
+    transform_title_episode,
+    display_dataframe_info
+)
 
 DATA_DIR = "imdb_data"
+FILE_EXTENSION = ".tsv"
+spark_session = initialize_spark("IMDB Data Processing")
 
 
 def check_pyspark() -> None:
@@ -10,32 +28,55 @@ def check_pyspark() -> None:
     spark = SparkSession.builder \
         .appName("IMDB Data Check") \
         .getOrCreate()
-    
+
     print("Spark Session initialized.")
     print("Checking available files...")
     files = [f for f in os.listdir(DATA_DIR) if f.endswith(".tsv")]
-    
+
     if not files:
         print("No TSV files found. Make sure data is downloaded and extracted.")
         return
-    
+
     print("Found files:", files)
 
     sample_file = os.path.join(DATA_DIR, files[0])
     print(f"Loading sample file: {sample_file}")
-    
+
     df = spark.read.option("header", "true").option("sep", "\t").csv(sample_file)
-    
+
     print("Schema of the loaded file:")
     df.printSchema()
-    
+
     print("Showing first 5 rows:")
     df.show(5)
-    
+
     print("PySpark check complete!")
-    
+
     spark.stop()
 
 
+def process_imdb_data() -> Dict[str, DataFrame]:
+    dataframes = {}
+
+    dataframes["basics"] = transform_title_basics(
+        load_dataframe(spark_session, schema_title_basics, f"{DATA_DIR}/title.basics{FILE_EXTENSION}")
+    )
+    dataframes["akas"] = transform_title_akas(
+        load_dataframe(spark_session, schema_title_akas, f"{DATA_DIR}/title.akas{FILE_EXTENSION}")
+    )
+    dataframes["crew"] = transform_title_crew(
+        load_dataframe(spark_session, schema_title_crew, f"{DATA_DIR}/title.crew{FILE_EXTENSION}")
+    )
+    dataframes["episode"] = transform_title_episode(
+        load_dataframe(spark_session, schema_title_episode, f"{DATA_DIR}/title.episode{FILE_EXTENSION}")
+    )
+
+    for name, df in dataframes.items():
+        display_dataframe_info(df, name)
+
+    return dataframes
+
+
 if __name__ == "__main__":
-    check_pyspark()
+    # check_pyspark()
+    process_imdb_data()

--- a/run_scripts.sh
+++ b/run_scripts.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 python download_dataset.py
+python schemas.py
+python imdb_spark_utils.py
 python main.py

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,41 @@
+import pyspark.sql.types as t
+
+# Схема для файлу title.akas.tsv
+schema_title_akas = t.StructType([
+    t.StructField("titleId", t.StringType(), nullable=False),
+    t.StructField("ordering", t.IntegerType(), nullable=True),
+    t.StructField("title", t.StringType(), nullable=True),
+    t.StructField("region", t.StringType(), nullable=True),
+    t.StructField("language", t.StringType(), nullable=True),
+    t.StructField("types", t.StringType(), nullable=True),
+    t.StructField("attributes", t.StringType(), nullable=True),
+    t.StructField("isOriginalTitle", t.StringType(), nullable=True)
+])
+
+# Схема для файлу title.basics.tsv
+schema_title_basics = t.StructType([
+    t.StructField("tconst", t.StringType(), nullable=False),
+    t.StructField("titleType", t.StringType(), nullable=True),
+    t.StructField("primaryTitle", t.StringType(), nullable=True),
+    t.StructField("originalTitle", t.StringType(), nullable=True),
+    t.StructField("isAdult", t.BooleanType(), nullable=True),
+    t.StructField("startYear", t.IntegerType(), nullable=True),
+    t.StructField("endYear", t.IntegerType(), nullable=True),
+    t.StructField("runtimeMinutes", t.IntegerType(), nullable=True),
+    t.StructField("genres", t.StringType(), nullable=True)
+])
+
+# Схема для файлу title.crew.tsv
+schema_title_crew = t.StructType([
+    t.StructField("tconst", t.StringType(), nullable=False),
+    t.StructField("directors", t.StringType(), nullable=True),
+    t.StructField("writers", t.StringType(), nullable=True)
+])
+
+# Схема для файлу title.episode.tsv
+schema_title_episode = t.StructType([
+    t.StructField("tconst", t.StringType(), nullable=False),
+    t.StructField("parentTconst", t.StringType(), nullable=False),
+    t.StructField("seasonNumber", t.IntegerType(), nullable=True),
+    t.StructField("episodeNumber", t.IntegerType(), nullable=True)
+])


### PR DESCRIPTION
Added initial IMDB data processing pipeline with custom schemas for title.basics.tsv, title.akas.tsv, title.crew.tsv, and title.episode.tsv, along with functions for Spark initialization, data loading, and transformation in a single script. Implemented basic data transformation logic for each dataset, including splitting array fields and type casting, and introduced a display function to show DataFrame details.